### PR TITLE
Fix Trino/Presto compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,15 @@ per the docs [here](https://trino.io/blog/2021/01/04/migrating-from-prestosql-to
 
 Note that this driver aims to be compliant with the [database/sql](https://pkg.go.dev/database/sql)
 package interface. In particular, only valid [driver.Value](https://pkg.go.dev/database/sql/driver#Value)
-types are returned (unlike the upstream Trino driver, which returns
-`map[string]interface{}` for `MAP` types and `[]interface{}` for `ARRAY`/`ROW`
-types). The driver therefore behaves as documented in the
+types are returned. The driver therefore behaves as documented in the
 [Rows.Scan](https://pkg.go.dev/database/sql#Rows.Scan) documentation.
+In particular, `MAP`, `ARRAY`, and `ROW` types are all returned as strings
+containing serialized JSON. This differs from the upstream Trino driver, which
+returns `map[string]interface{}` for `MAP` types and `[]interface{}` for
+`ARRAY`/`ROW` types (and is therefore non-compliant with the `driver.Value`
+interface requirements).
 
-Note that all date and time types are returned as strings, to maintain the
+Note that all date and time types are also returned as strings to maintain the
 precise format in which they're returned from Presto/Trino itself.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,19 +1,23 @@
 # Presto Go client
 
 A [Presto](http://prestodb.io/) client for the [Go](https://golang.org)
-programming language, adapted from [github.com/trinodb/trino-go-client](https://github.com/trinodb/trino-go-client)
-(mostly just replacing "trino" with "presto" in the source files). See those
-docs for more details. Note that some Trino-specific features won't work with
-Presto.
+programming language, adapted from [github.com/trinodb/trino-go-client](https://github.com/trinodb/trino-go-client).
+
+This library strips out some of the more advanced Trino-specific functionality
+(such as the advanced type-scanning logic) and adapts it to work with Presto.
+This library also works with Trino when configured in Presto-compatibility mode,
+per the docs [here](https://trino.io/blog/2021/01/04/migrating-from-prestosql-to-trino.html#client-protocol-compatiblity).
+
+Note that this driver aims to be compliant with the [database/sql](https://pkg.go.dev/database/sql)
+package interface. In particular, only valid [driver.Value](https://pkg.go.dev/database/sql/driver#Value)
+types are returned (unlike the upstream Trino driver, which returns
+`map[string]interface{}` for `MAP` types and `[]interface{}` for `ARRAY`/`ROW`
+types). The driver therefore behaves as documented in the
+[Rows.Scan](https://pkg.go.dev/database/sql#Rows.Scan) documentation.
+
+Note that all date and time types are returned as strings, to maintain the
+precise format in which they're returned from Presto/Trino itself.
 
 ## License
 
 Apache License V2.0, as described in the [LICENSE](./LICENSE) file.
-
-## Build
-
-You can build the client code locally and run tests with the following command:
-
-```
-go test -v -race -timeout 2m ./...
-```

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -1292,6 +1292,19 @@ func newOptionalInt64(value int64) optionalInt64 {
 	return optionalInt64{value: value, hasValue: true}
 }
 
+func argIsLong(signature typeSignature, argIdx int) bool {
+	if len(signature.Arguments) <= argIdx {
+		return false
+	}
+
+	switch signature.Arguments[argIdx].Kind {
+	case KIND_LONG, KIND_LONG_LITERAL:
+		return true
+	}
+
+	return false
+}
+
 func newTypeConverter(typeName string, signature typeSignature) (*typeConverter, error) {
 	result := &typeConverter{
 		typeName:   typeName,
@@ -1304,18 +1317,18 @@ func newTypeConverter(typeName string, signature typeSignature) (*typeConverter,
 	}
 	switch signature.RawType {
 	case "char", "varchar":
-		if len(signature.Arguments) > 0 && signature.Arguments[0].Kind == KIND_LONG_LITERAL {
+		if argIsLong(signature, 0) {
 			result.size = newOptionalInt64(signature.Arguments[0].long)
 		}
 	case "decimal":
-		if len(signature.Arguments) > 0 && signature.Arguments[0].Kind == KIND_LONG_LITERAL {
+		if argIsLong(signature, 0) {
 			result.precision = newOptionalInt64(signature.Arguments[0].long)
 		}
-		if len(signature.Arguments) > 1 && signature.Arguments[1].Kind == KIND_LONG_LITERAL {
+		if argIsLong(signature, 1) {
 			result.scale = newOptionalInt64(signature.Arguments[1].long)
 		}
 	case "time", "time with time zone", "timestamp", "timestamp with time zone":
-		if len(signature.Arguments) > 0 && signature.Arguments[0].Kind == KIND_LONG_LITERAL {
+		if argIsLong(signature, 0) {
 			result.precision = newOptionalInt64(signature.Arguments[0].long)
 		}
 	}

--- a/presto/presto.go
+++ b/presto/presto.go
@@ -1409,6 +1409,12 @@ func validateMap(v interface{}) error {
 		return nil
 	}
 
+	// Trino returns maps as a JSON object
+	if _, ok := v.(map[string]interface{}); ok {
+		return nil
+	}
+
+	// Presto returns maps as a string containing a serialized JSON object
 	str, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("cannot convert %v (%T) to map", v, v)
@@ -1427,6 +1433,12 @@ func validateSlice(v interface{}) error {
 		return nil
 	}
 
+	// Trino returns maps as a JSON array
+	if _, ok := v.([]interface{}); ok {
+		return nil
+	}
+
+	// Presto returns maps as a string containing a serialized JSON array
 	str, ok := v.(string)
 	if !ok {
 		return fmt.Errorf("cannot convert %v (%T) to slice", v, v)


### PR DESCRIPTION
This PR is a follow-up to #4. Some of the changes I made in that PR assumed that the driver library would be communicating with a "real" Presto server instance. However, some users may be connecting to a Trino instance configured to be compatible with Presto, as described in the Trino docs [here](https://trino.io/blog/2021/01/04/migrating-from-prestosql-to-trino.html#client-protocol-compatiblity):

> Out of the box, the Trino server does not work with older clients. However, in order to support a graceful transition, you can allow the server to support older clients by adding a configuration property:
>
> ```
> protocol.v1.alternate-header-name=Presto
> ```

This PR makes the necessary changes for this library to be compatible with Trino instances configured in this way. In particular, it updates the driver to accept the type argument "kinds" returned by both Trino and Presto (which are slightly different). Additionally, it updates the logic for scanning map/array/row results to handle either strings containing serialized JSON (as returned from Presto) or actual JSON arrays/objects (as returned from Trino). In either case, the results are normalized to strings containing serialized JSON (because this maintains compliance with the rules for a [driver.Value](https://pkg.go.dev/database/sql/driver#Value)).